### PR TITLE
feat: support atoms=None in PyCV to select all atoms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hillclimber"
-version = "0.1.6"
+version = "0.1.7"
 description = "Python interfaces for the plumed library with enhanced sampling."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/hillclimber/pycv.py
+++ b/src/hillclimber/pycv.py
@@ -33,8 +33,9 @@ class PyCV(ABC):
 
     Parameters
     ----------
-    atoms : AtomSelector | list[int]
-        Atoms to pass to the CV. Either an AtomSelector or direct indices (0-based).
+    atoms : AtomSelector | list[int] | None
+        Atoms to pass to the CV. Either an AtomSelector, direct indices (0-based),
+        or None to select all atoms.
     prefix : str
         Label prefix for PLUMED commands.
 
@@ -75,7 +76,7 @@ class PyCV(ABC):
     the CV can only be printed/monitored.
     """
 
-    atoms: AtomSelector | list[int]
+    atoms: AtomSelector | list[int] | None
     prefix: str
 
     @abstractmethod
@@ -191,7 +192,10 @@ class PyCV(ABC):
         list[int]
             Flat list of 0-based atom indices.
         """
-        if isinstance(self.atoms, list):
+        if self.atoms is None:
+            # None means all atoms
+            return list(range(len(atoms)))
+        elif isinstance(self.atoms, list):
             return self.atoms
         else:
             # AtomSelector returns list[list[int]], flatten it
@@ -227,7 +231,9 @@ class PyCV(ABC):
             Python code string for initializing this PyCV instance.
         """
         # Serialize atoms argument
-        if isinstance(self.atoms, list):
+        if self.atoms is None:
+            atoms_repr = "None"
+        elif isinstance(self.atoms, list):
             atoms_repr = repr(self.atoms)
         else:
             # AtomSelector - use dataclass fields for serialization

--- a/tests/test_pycv_cv.py
+++ b/tests/test_pycv_cv.py
@@ -39,6 +39,40 @@ class SimpleDistanceCV(PyCV):
 class TestPyCVBasic:
     """Basic PyCV functionality tests."""
 
+    def test_pycv_with_atoms_none_selects_all_atoms(self):
+        """Test PyCV with atoms=None selects all atoms."""
+        cv = SimpleDistanceCV(atoms=None, prefix="d_all")
+
+        atoms = Atoms("Ar3", positions=[[0, 0, 0], [3.8, 0, 0], [7.6, 0, 0]])
+
+        labels, commands = cv.to_plumed(atoms)
+
+        expected = [
+            "d_all: PYCVINTERFACE ATOMS=1,2,3 IMPORT=_pycv_d_all",
+        ]
+
+        assert labels == ["d_all"]
+        assert commands == expected
+
+    def test_pycv_with_atoms_none_larger_system(self):
+        """Test PyCV with atoms=None on a larger system."""
+        cv = SimpleDistanceCV(atoms=None, prefix="d_full")
+
+        atoms = Atoms("C2H6", positions=[
+            [0, 0, 0], [1.54, 0, 0],  # C atoms
+            [0, 1, 0], [0, -1, 0], [0, 0, 1],  # H on first C
+            [1.54, 1, 0], [1.54, -1, 0], [1.54, 0, 1],  # H on second C
+        ])
+
+        labels, commands = cv.to_plumed(atoms)
+
+        expected = [
+            "d_full: PYCVINTERFACE ATOMS=1,2,3,4,5,6,7,8 IMPORT=_pycv_d_full",
+        ]
+
+        assert labels == ["d_full"]
+        assert commands == expected
+
     def test_pycv_with_index_list(self):
         """Test PyCV with direct list of atom indices."""
         cv = SimpleDistanceCV(atoms=[0, 1], prefix="d_simple")
@@ -95,6 +129,14 @@ class TestPyCVBasic:
 
 class TestPyCVInitArgs:
     """Tests for get_init_args serialization."""
+
+    def test_init_args_with_none(self):
+        """Test get_init_args with atoms=None."""
+        cv = SimpleDistanceCV(atoms=None, prefix="d_all")
+
+        init_args = cv.get_init_args()
+
+        assert init_args == "atoms=None, prefix='d_all'"
 
     def test_init_args_with_list(self):
         """Test get_init_args with list of indices."""

--- a/uv.lock
+++ b/uv.lock
@@ -1099,7 +1099,7 @@ wheels = [
 
 [[package]]
 name = "hillclimber"
-version = "0.1.5"
+version = "0.1.7"
 source = { editable = "." }
 dependencies = [
     { name = "ase" },


### PR DESCRIPTION
Allow PyCV.atoms to be None, which selects all atoms in the system. This is useful when the CV computation needs access to all atomic positions (e.g., for global descriptors or neural network potentials).

- Update type annotation: `atoms: AtomSelector | list[int] | None`
- Handle None in _get_atom_indices() to return all indices
- Handle None in get_init_args() for proper serialization
- Add tests for atoms=None behavior
- Bump version to 0.1.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PyCV now accepts `atoms=None` to automatically select all atoms, providing a convenient default behavior.

* **Chores**
  * Version updated to 0.1.7.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->